### PR TITLE
Add setReturnGeneratedKeys to PreparedStatementCreatorFactory

### DIFF
--- a/ch03/tacos-jdbc/src/main/java/tacos/data/JdbcTacoRepository.java
+++ b/ch03/tacos-jdbc/src/main/java/tacos/data/JdbcTacoRepository.java
@@ -37,14 +37,15 @@ public class JdbcTacoRepository implements TacoRepository {
 
   private long saveTacoInfo(Taco taco) {
     taco.setCreatedAt(new Date());
-    PreparedStatementCreator psc =
-        new PreparedStatementCreatorFactory(
+    PreparedStatementCreatorFactory pscf = new PreparedStatementCreatorFactory(
             "insert into Taco (name, createdAt) values (?, ?)",
             Types.VARCHAR, Types.TIMESTAMP
-        ).newPreparedStatementCreator(
+    );
+    pscf.setReturnGeneratedKeys(true);
+    PreparedStatementCreator psc = pscf.newPreparedStatementCreator(
             Arrays.asList(
-                taco.getName(),
-                new Timestamp(taco.getCreatedAt().getTime())));
+                    taco.getName(),
+                    new Timestamp(taco.getCreatedAt().getTime())));
 
     KeyHolder keyHolder = new GeneratedKeyHolder();
     jdbc.update(psc, keyHolder);


### PR DESCRIPTION
Due to https://github.com/habuma/spring-in-action-5-samples/issues/25
added setReturnGeneratedKeys(true) to PreparedStatementCreatorFactory in JdbcTacoRepository.saveTacoInfo method