### PR TITLE
Fix null form ingredients

### DIFF
--- a/ch03/tacos-jdbc/src/main/java/tacos/Taco.java
+++ b/ch03/tacos-jdbc/src/main/java/tacos/Taco.java
@@ -21,7 +21,7 @@ public class Taco {
   @Size(min=5, message="Name must be at least 5 characters long")
   private String name;
   
-  @Size(min=1, message="You must choose at least 1 ingredient")
+  @NotNull(message="You must choose at least 1 ingredient")
   private List<Ingredient> ingredients;
 
   /*

--- a/ch03/tacos-jdbc/src/main/java/tacos/web/DesignTacoController.java
+++ b/ch03/tacos-jdbc/src/main/java/tacos/web/DesignTacoController.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +16,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.SessionAttributes;
 
-import tacos.Taco;
 import tacos.Ingredient;
 import tacos.Ingredient.Type;
 import tacos.Order;
-import tacos.data.TacoRepository;
+import tacos.Taco;
 import tacos.data.IngredientRepository;
+import tacos.data.TacoRepository;
 
 // tag::classShell[]
 @Controller
@@ -72,20 +71,22 @@ public class DesignTacoController {
     return new Taco();
   }
 
+  @ModelAttribute
+  public void addIngredientsToModel(Model model) {
+
+	List<Ingredient> ingredients = new ArrayList<>();
+	ingredientRepo.findAll().forEach(ingredients::add);
+	Type[] types = Ingredient.Type.values();
+	for (Type type : types) {
+		model.addAttribute(type.toString().toLowerCase(), filterByType(ingredients, type));
+	}
+  }
+
   // end::modelAttributes[]
   // tag::showDesignForm[]
   
   @GetMapping
   public String showDesignForm(Model model) {
-    List<Ingredient> ingredients = new ArrayList<>();
-    ingredientRepo.findAll().forEach(i -> ingredients.add(i));
-    
-    Type[] types = Ingredient.Type.values();
-    for (Type type : types) {
-      model.addAttribute(type.toString().toLowerCase(), 
-          filterByType(ingredients, type));      
-    }
-
     return "design";
   }
 //end::showDesignForm[]
@@ -93,8 +94,7 @@ public class DesignTacoController {
   //tag::processDesign[]
   @PostMapping
   public String processDesign(
-      @Valid Taco design, Errors errors, 
-      @ModelAttribute Order order) {
+			@ModelAttribute @Valid Taco design, Errors errors, @ModelAttribute Order order) {
 
     if (errors.hasErrors()) {
       return "design";


### PR DESCRIPTION
The design form is returning null when no ingredients are checked. This changes the constraint on the Taco model so that the ingredients field is checked for null, instead of size.

The DesignTacoController refactor from Chapter 2 is also included in this commit.