### PR TITLE
Update spring-boot-starter-parent version, fixes #60

### DIFF
--- a/ch01/tacos/pom.xml
+++ b/ch01/tacos/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.4.RELEASE</version>                    <!--2-->
+    <version>2.0.9.RELEASE</version>                    <!--2-->
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
This is necessary for the project to run without runtime exceptions for missing class definitions