### PR TITLE
[fix] fix the problem of [no PasswordEncoder mapped for the id “null”]

### DIFF
--- a/ch04/tacos/src/main/java/tacos/security/SecurityConfig.java
+++ b/ch04/tacos/src/main/java/tacos/security/SecurityConfig.java
@@ -125,11 +125,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     auth
       .inMemoryAuthentication()
         .withUser("buzz")
-          .password("infinity")
+          .password("{noop}infinity")
           .authorities("ROLE_USER")
         .and()
         .withUser("woody")
-          .password("bullseye")
+          .password("{noop}bullseye")
           .authorities("ROLE_USER");
     
   }


### PR DESCRIPTION
Prior to Spring Security 5.0 the default PasswordEncoder was NoOpPasswordEncoder which required plain text passwords. In Spring Security 5, the default is DelegatingPasswordEncoder, which required Password Storage Format.So we can  add password storage format, for plain text, add {noop} to solve this problem.
some details info:[Spring Security 5.0.0.RC1 Released](https://spring.io/blog/2017/11/01/spring-security-5-0-0-rc1-released#password-storage-format)