### PR TITLE
Fix missing primary key on id field

### DIFF
--- a/ch03/tacos-jdbc/src/main/resources/schema.sql
+++ b/ch03/tacos-jdbc/src/main/resources/schema.sql
@@ -1,5 +1,5 @@
 create table if not exists Ingredient (
-  id varchar(4) not null,
+  id varchar(4) not null primary key,
   name varchar(25) not null,
   type varchar(10) not null
 );


### PR DESCRIPTION
You can't use it as a foreign key if it is not a primary key—besides, the application crashes.